### PR TITLE
Fix initialization of auth request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ config :gotrue,
 
   # The private access token
   access_token: "your-super-secret-operator-token"
+
+  # Request header to use to send the access_token
+  # e.g. for Netlify GoTrue set
+  # auth_header: :Authorization
+  #
+  # for Supabase
+  # auth_header: :apikey
+  #
+  # default is set to :apikey
+
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ def deps do
 end
 ```
 
-In your `config/dev.exs` & `config/prod.exs`, configure settings: 
+In your `config/dev.exs` & `config/prod.exs`, configure settings:
 
 ```elixir
 config :gotrue,
@@ -42,15 +42,6 @@ config :gotrue,
 
   # The private access token
   access_token: "your-super-secret-operator-token"
-
-  # Request header to use to send the access_token
-  # e.g. for Netlify GoTrue set
-  # auth_header: :Authorization
-  #
-  # for Supabase
-  # auth_header: :apikey
-  #
-  # default is set to :apikey
 
 ```
 
@@ -70,7 +61,7 @@ GoTrue.sign_up(%{email: "user@example.com", password: "123456"})
 
 ### OAUTH2
 
-Oauth is performed on the client by redirecting the user. To get the redirection URL, call `GoTrue.url_for_provider/1`: 
+Oauth is performed on the client by redirecting the user. To get the redirection URL, call `GoTrue.url_for_provider/1`:
 
 ```elixir
 GoTrue.url_for_provider(:google)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ config :gotrue,
   # URL to your GoTrue instance
   base_url: "http://0.0.0.0:9999",
 
-  # The private access token
-  access_token: "your-super-secret-operator-token"
+  # The project's API key
+  api_key: "your-super-secret-operator-token"
 
 ```
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,4 +2,4 @@ import Config
 
 config :gotrue,
   base_url: "http://0.0.0.0:9999",
-  access_token: "super-secret-operator-token"
+  api_key: "super-secret-operator-token"

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,4 +4,4 @@ config :tesla, adapter: Tesla.Mock
 
 config :gotrue,
   base_url: "http://auth.example.com",
-  access_token: "super-secret"
+  api_key: "super-secret"

--- a/lib/gotrue.ex
+++ b/lib/gotrue.ex
@@ -120,7 +120,7 @@ defmodule GoTrue do
     middlewares = [
       {Tesla.Middleware.BaseUrl, @base_url},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [{:apikey, @access_token}, {:Authorization, access_token}]}
+      {Tesla.Middleware.Headers, [{:apikey, @access_token}, {:authorization, access_token}]}
     ]
 
     Tesla.client(middlewares)

--- a/lib/gotrue.ex
+++ b/lib/gotrue.ex
@@ -7,7 +7,6 @@ defmodule GoTrue do
 
   @base_url Application.get_env(:gotrue, :base_url, "http://0.0.0.0:9999")
   @access_token Application.get_env(:gotrue, :access_token)
-  @auth_header Application.get_env(:gotrue, :auth_header, "apikey")
 
   @doc "Get environment settings for the server"
   @spec settings() :: map
@@ -121,25 +120,10 @@ defmodule GoTrue do
     middlewares = [
       {Tesla.Middleware.BaseUrl, @base_url},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [auth_header(@auth_header, access_token)]}
+      {Tesla.Middleware.Headers, [{:apikey, @access_token}, {:Authorization, access_token}]}
     ]
 
     Tesla.client(middlewares)
-  end
-
-  defp auth_header("authorization", access_token), do: {:Authorization, "Bearer #{access_token}"}
-  defp auth_header("apikey", access_token), do: {:apikey, access_token}
-
-  defp auth_header(header_key, access_token) when is_atom(header_key) do
-    header_key
-    |> Atom.to_string()
-    |> auth_header(access_token)
-  end
-
-  defp auth_header(header_key, access_token) do
-    header_key
-    |> String.downcase()
-    |> auth_header(access_token)
   end
 
   defp parse_user(user) do

--- a/lib/gotrue.ex
+++ b/lib/gotrue.ex
@@ -6,7 +6,7 @@ defmodule GoTrue do
   import Tesla, only: [get: 2, post: 3, put: 3]
 
   @base_url Application.get_env(:gotrue, :base_url, "http://0.0.0.0:9999")
-  @api_key Application.get_env(:gotrue, :access_token)
+  @api_key Application.get_env(:gotrue, :api_key)
 
   @doc "Get environment settings for the server"
   @spec settings() :: map

--- a/lib/gotrue.ex
+++ b/lib/gotrue.ex
@@ -6,7 +6,7 @@ defmodule GoTrue do
   import Tesla, only: [get: 2, post: 3, put: 3]
 
   @base_url Application.get_env(:gotrue, :base_url, "http://0.0.0.0:9999")
-  @access_token Application.get_env(:gotrue, :access_token)
+  @api_key Application.get_env(:gotrue, :access_token)
 
   @doc "Get environment settings for the server"
   @spec settings() :: map
@@ -116,11 +116,11 @@ defmodule GoTrue do
     |> handle_response(200, &user_handler/1)
   end
 
-  defp client(access_token \\ @access_token) do
+  defp client(access_token \\ @api_key) do
     middlewares = [
       {Tesla.Middleware.BaseUrl, @base_url},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [{:apikey, @access_token}, {:authorization, access_token}]}
+      {Tesla.Middleware.Headers, [{:apikey, @api_key}, {:authorization, access_token}]}
     ]
 
     Tesla.client(middlewares)

--- a/lib/gotrue.ex
+++ b/lib/gotrue.ex
@@ -7,6 +7,7 @@ defmodule GoTrue do
 
   @base_url Application.get_env(:gotrue, :base_url, "http://0.0.0.0:9999")
   @access_token Application.get_env(:gotrue, :access_token)
+  @auth_header Application.get_env(:gotrue, :auth_header, "apikey")
 
   @doc "Get environment settings for the server"
   @spec settings() :: map
@@ -120,10 +121,25 @@ defmodule GoTrue do
     middlewares = [
       {Tesla.Middleware.BaseUrl, @base_url},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, authorization: "Bearer #{access_token}"}
+      {Tesla.Middleware.Headers, [auth_header(@auth_header, access_token)]}
     ]
 
     Tesla.client(middlewares)
+  end
+
+  defp auth_header("authorization", access_token), do: {:Authorization, "Bearer #{access_token}"}
+  defp auth_header("apikey", access_token), do: {:apikey, access_token}
+
+  defp auth_header(header_key, access_token) when is_atom(header_key) do
+    header_key
+    |> Atom.to_string()
+    |> auth_header(access_token)
+  end
+
+  defp auth_header(header_key, access_token) do
+    header_key
+    |> String.downcase()
+    |> auth_header(access_token)
   end
 
   defp parse_user(user) do

--- a/test/gotrue_test.exs
+++ b/test/gotrue_test.exs
@@ -156,7 +156,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/token?grant_type=password",
           headers: [
             {"content-type", "application/json"},
-            apikey: "super-secret"
+            apikey: "super-secret",
+            Authorization: "super-secret"
           ],
           body: ~s|{"email":"user@example.com","password":"12345"}|
         } ->
@@ -174,7 +175,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/token?grant_type=password",
           headers: [
             {"content-type", "application/json"},
-            apikey: "super-secret"
+            apikey: "super-secret",
+            Authorization: "super-secret"
           ],
           body: ~s|{"email":"user@example.com","password":"12345"}|
         } ->
@@ -194,7 +196,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/token?grant_type=refresh_token",
           headers: [
             {"content-type", "application/json"},
-            apikey: "super-secret"
+            apikey: "super-secret",
+            Authorization: "super-secret"
           ],
           body: ~s|{"refresh_token":"refresh-token"}|
         } ->
@@ -212,7 +215,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/token?grant_type=refresh_token",
           headers: [
             {"content-type", "application/json"},
-            apikey: "super-secret"
+            apikey: "super-secret",
+            Authorization: "super-secret"
           ],
           body: ~s|{"refresh_token":"refresh-token"}|
         } ->
@@ -231,7 +235,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/logout",
           headers: [
             {"content-type", "application/json"},
-            apikey: "jwt-access-token"
+            apikey: "super-secret",
+            Authorization: "jwt-access-token"
           ]
         } ->
           json(%{"msg" => "invalid token"}, status: 422)
@@ -248,7 +253,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/logout",
           headers: [
             {"content-type", "application/json"},
-            apikey: "jwt-access-token"
+            apikey: "super-secret",
+            Authorization: "jwt-access-token"
           ]
         } ->
           json(%{}, status: 204)
@@ -299,7 +305,7 @@ defmodule GoTrueTest do
         %{
           method: :get,
           url: "http://auth.example.com/user",
-          headers: [apikey: "jwt-access-token"]
+          headers: [apikey: "super-secret", Authorization: "jwt-access-token"]
         } ->
           json(%{"msg" => "invalid token"}, status: 422)
       end)
@@ -313,7 +319,7 @@ defmodule GoTrueTest do
         %{
           method: :get,
           url: "http://auth.example.com/user",
-          headers: [apikey: "jwt-access-token"]
+          headers: [apikey: "super-secret", Authorization: "jwt-access-token"]
         } ->
           json(%{"email" => "user@example.com"})
       end)
@@ -330,7 +336,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/user",
           headers: [
             {"content-type", "application/json"},
-            apikey: "jwt-access-token"
+            apikey: "super-secret",
+            Authorization: "jwt-access-token"
           ],
           body: ~s|{"data":{"name":"Josh"}}|
         } ->
@@ -348,7 +355,8 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/user",
           headers: [
             {"content-type", "application/json"},
-            apikey: "jwt-access-token"
+            apikey: "super-secret",
+            Authorization: "jwt-access-token"
           ],
           body: ~s|{"data":{"name":"Josh"}}|
         } ->

--- a/test/gotrue_test.exs
+++ b/test/gotrue_test.exs
@@ -154,7 +154,10 @@ defmodule GoTrueTest do
         %{
           method: :post,
           url: "http://auth.example.com/token?grant_type=password",
-          headers: [{"content-type", "application/json"}, authorization: "Bearer super-secret"],
+          headers: [
+            {"content-type", "application/json"},
+            apikey: "super-secret"
+          ],
           body: ~s|{"email":"user@example.com","password":"12345"}|
         } ->
           json(%{"msg" => "invalid password"}, status: 422)
@@ -169,7 +172,10 @@ defmodule GoTrueTest do
         %{
           method: :post,
           url: "http://auth.example.com/token?grant_type=password",
-          headers: [{"content-type", "application/json"}, authorization: "Bearer super-secret"],
+          headers: [
+            {"content-type", "application/json"},
+            apikey: "super-secret"
+          ],
           body: ~s|{"email":"user@example.com","password":"12345"}|
         } ->
           json(%{"access_token" => "1234"})
@@ -186,7 +192,10 @@ defmodule GoTrueTest do
         %{
           method: :post,
           url: "http://auth.example.com/token?grant_type=refresh_token",
-          headers: [{"content-type", "application/json"}, authorization: "Bearer super-secret"],
+          headers: [
+            {"content-type", "application/json"},
+            apikey: "super-secret"
+          ],
           body: ~s|{"refresh_token":"refresh-token"}|
         } ->
           json(%{"msg" => "invalid token"}, status: 422)
@@ -201,7 +210,10 @@ defmodule GoTrueTest do
         %{
           method: :post,
           url: "http://auth.example.com/token?grant_type=refresh_token",
-          headers: [{"content-type", "application/json"}, authorization: "Bearer super-secret"],
+          headers: [
+            {"content-type", "application/json"},
+            apikey: "super-secret"
+          ],
           body: ~s|{"refresh_token":"refresh-token"}|
         } ->
           json(%{"access_token" => "1234"})
@@ -219,7 +231,7 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/logout",
           headers: [
             {"content-type", "application/json"},
-            authorization: "Bearer jwt-access-token"
+            apikey: "jwt-access-token"
           ]
         } ->
           json(%{"msg" => "invalid token"}, status: 422)
@@ -236,7 +248,7 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/logout",
           headers: [
             {"content-type", "application/json"},
-            authorization: "Bearer jwt-access-token"
+            apikey: "jwt-access-token"
           ]
         } ->
           json(%{}, status: 204)
@@ -287,7 +299,7 @@ defmodule GoTrueTest do
         %{
           method: :get,
           url: "http://auth.example.com/user",
-          headers: [authorization: "Bearer jwt-access-token"]
+          headers: [apikey: "jwt-access-token"]
         } ->
           json(%{"msg" => "invalid token"}, status: 422)
       end)
@@ -301,7 +313,7 @@ defmodule GoTrueTest do
         %{
           method: :get,
           url: "http://auth.example.com/user",
-          headers: [authorization: "Bearer jwt-access-token"]
+          headers: [apikey: "jwt-access-token"]
         } ->
           json(%{"email" => "user@example.com"})
       end)
@@ -318,7 +330,7 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/user",
           headers: [
             {"content-type", "application/json"},
-            authorization: "Bearer jwt-access-token"
+            apikey: "jwt-access-token"
           ],
           body: ~s|{"data":{"name":"Josh"}}|
         } ->
@@ -336,7 +348,7 @@ defmodule GoTrueTest do
           url: "http://auth.example.com/user",
           headers: [
             {"content-type", "application/json"},
-            authorization: "Bearer jwt-access-token"
+            apikey: "jwt-access-token"
           ],
           body: ~s|{"data":{"name":"Josh"}}|
         } ->

--- a/test/gotrue_test.exs
+++ b/test/gotrue_test.exs
@@ -157,7 +157,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "super-secret"
+            authorization: "super-secret"
           ],
           body: ~s|{"email":"user@example.com","password":"12345"}|
         } ->
@@ -176,7 +176,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "super-secret"
+            authorization: "super-secret"
           ],
           body: ~s|{"email":"user@example.com","password":"12345"}|
         } ->
@@ -197,7 +197,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "super-secret"
+            authorization: "super-secret"
           ],
           body: ~s|{"refresh_token":"refresh-token"}|
         } ->
@@ -216,7 +216,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "super-secret"
+            authorization: "super-secret"
           ],
           body: ~s|{"refresh_token":"refresh-token"}|
         } ->
@@ -236,7 +236,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "jwt-access-token"
+            authorization: "jwt-access-token"
           ]
         } ->
           json(%{"msg" => "invalid token"}, status: 422)
@@ -254,7 +254,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "jwt-access-token"
+            authorization: "jwt-access-token"
           ]
         } ->
           json(%{}, status: 204)
@@ -305,7 +305,7 @@ defmodule GoTrueTest do
         %{
           method: :get,
           url: "http://auth.example.com/user",
-          headers: [apikey: "super-secret", Authorization: "jwt-access-token"]
+          headers: [apikey: "super-secret", authorization: "jwt-access-token"]
         } ->
           json(%{"msg" => "invalid token"}, status: 422)
       end)
@@ -319,7 +319,7 @@ defmodule GoTrueTest do
         %{
           method: :get,
           url: "http://auth.example.com/user",
-          headers: [apikey: "super-secret", Authorization: "jwt-access-token"]
+          headers: [apikey: "super-secret", authorization: "jwt-access-token"]
         } ->
           json(%{"email" => "user@example.com"})
       end)
@@ -337,7 +337,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "jwt-access-token"
+            authorization: "jwt-access-token"
           ],
           body: ~s|{"data":{"name":"Josh"}}|
         } ->
@@ -356,7 +356,7 @@ defmodule GoTrueTest do
           headers: [
             {"content-type", "application/json"},
             apikey: "super-secret",
-            Authorization: "jwt-access-token"
+            authorization: "jwt-access-token"
           ],
           body: ~s|{"data":{"name":"Josh"}}|
         } ->


### PR DESCRIPTION
This enables support for different platforms, e.g. Netlify uses the `Authorization` header with a `Bearer {tocken}` and Supabase uses the `apikey` header.

We could also think about simply setting both headers like in supabase's JS client: https://github.com/supabase/supabase-js/blob/master/src/SupabaseClient.ts#L147